### PR TITLE
Fix find elements methods to use `object_id` instead of `node_id`

### DIFF
--- a/pydoll/browser/base.py
+++ b/pydoll/browser/base.py
@@ -1,7 +1,9 @@
 import asyncio
 import os
+import shutil
 import subprocess
 from abc import ABC, abstractmethod
+from contextlib import suppress
 from functools import partial
 from random import randint
 from tempfile import TemporaryDirectory
@@ -53,7 +55,8 @@ class Browser(ABC):  # noqa: PLR0904
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.stop()
         for temp_dir in self.temp_dirs:
-            temp_dir.cleanup()
+            with suppress(OSError):
+                shutil.rmtree(temp_dir.name)
         await self.connection_handler.close()
 
     async def start(self) -> None:

--- a/pydoll/browser/page.py
+++ b/pydoll/browser/page.py
@@ -349,7 +349,7 @@ class Page(FindElementsMixin):  # noqa: PLR0904
         if element:
             script = script.replace('argument', 'this')
             script = f'function(){{ {script} }}'
-            object_id = element._node['objectId']
+            object_id = element._object_id
             command = RuntimeCommands.call_function_on(
                 object_id, script, return_by_value=True
             )

--- a/pydoll/commands/dom.py
+++ b/pydoll/commands/dom.py
@@ -103,13 +103,14 @@ class DomCommands:
     ) -> dict:
         """Generates a command to find a DOM element based on the specified
         criteria."""
+        escaped_value = value.replace('"', '\\"')
         match by:
             case By.CLASS_NAME:
-                selector = f'.{value}'
+                selector = f'.{escaped_value}'
             case By.ID:
-                selector = f'#{value}'
+                selector = f'#{escaped_value}'
             case _:
-                selector = value
+                selector = escaped_value
         if object_id and not by == By.XPATH:
             script = f'''
             function() {{
@@ -138,13 +139,14 @@ class DomCommands:
     ) -> dict:
         """Generates a command to find multiple DOM elements based on the
         specified criteria."""
+        escaped_value = value.replace('"', '\\"')
         match by:
             case By.CLASS_NAME:
-                selector = f'.{value}'
+                selector = f'.{escaped_value}'
             case By.ID:
-                selector = f'#{value}'
+                selector = f'#{escaped_value}'
             case _:
-                selector = value
+                selector = escaped_value
         if object_id and not by == By.XPATH:
             script = f'''
             function() {{
@@ -169,6 +171,7 @@ class DomCommands:
         """Creates a command to find a DOM element by XPath."""
         escaped_value = xpath.replace('"', '\\"')
         if object_id:
+            escaped_value = cls._ensure_relative_xpath(escaped_value)
             command = copy.deepcopy(RuntimeCommands.CALL_FUNCTION_ON_TEMPLATE)
             command['params']['objectId'] = object_id
             command['params']['functionDeclaration'] = (
@@ -196,6 +199,7 @@ class DomCommands:
         """Creates a command to find multiple DOM elements by XPath."""
         escaped_value = xpath.replace('"', '\\"')
         if object_id:
+            escaped_value = cls._ensure_relative_xpath(escaped_value)
             command = copy.deepcopy(RuntimeCommands.CALL_FUNCTION_ON_TEMPLATE)
             command['params']['objectId'] = object_id
             command['params']['functionDeclaration'] = (
@@ -225,3 +229,8 @@ class DomCommands:
                 'results;'
             )
         return command
+
+    @staticmethod
+    def _ensure_relative_xpath(xpath: str) -> str:
+        """Ensures that the XPath expression is relative."""
+        return f'.{xpath}' if not xpath.startswith('.') else xpath

--- a/pydoll/commands/dom.py
+++ b/pydoll/commands/dom.py
@@ -52,7 +52,7 @@ class DomCommands:
         command = copy.deepcopy(cls.GET_OUTER_HTML)
         command['params']['objectId'] = object_id
         return command
-    
+
     @classmethod
     def dom_document(cls) -> dict:
         """

--- a/pydoll/commands/dom.py
+++ b/pydoll/commands/dom.py
@@ -2,7 +2,7 @@ import copy
 from typing import Literal
 
 from pydoll.commands.runtime import RuntimeCommands
-from pydoll.constants import By
+from pydoll.constants import By, Scripts
 
 
 class DomCommands:
@@ -112,11 +112,9 @@ class DomCommands:
             case _:
                 selector = escaped_value
         if object_id and not by == By.XPATH:
-            script = f'''
-            function() {{
-                return this.querySelector("{selector}");
-            }}
-            '''
+            script = Scripts.RELATIVE_QUERY_SELECTOR.replace(
+                '{selector}', escaped_value
+            )
             command = RuntimeCommands.call_function_on(
                 object_id,
                 script,
@@ -126,7 +124,7 @@ class DomCommands:
             command = cls._find_element_by_xpath(value, object_id)
         else:
             command = RuntimeCommands.evaluate_script(
-                f'document.querySelector("{selector}");'
+                Scripts.QUERY_SELECTOR.replace('{selector}', selector)
             )
         return command
 
@@ -148,11 +146,9 @@ class DomCommands:
             case _:
                 selector = escaped_value
         if object_id and not by == By.XPATH:
-            script = f'''
-            function() {{
-                return this.querySelectorAll("{selector}");
-            }}
-            '''
+            script = Scripts.RELATIVE_QUERY_SELECTOR_ALL.replace(
+                '{selector}', escaped_value
+            )
             command = RuntimeCommands.call_function_on(
                 object_id,
                 script,
@@ -162,7 +158,7 @@ class DomCommands:
             command = cls._find_elements_by_xpath(value, object_id)
         else:
             command = RuntimeCommands.evaluate_script(
-                f'document.querySelectorAll("{selector}");'
+                Scripts.QUERY_SELECTOR_ALL.replace('{selector}', selector)
             )
         return command
 
@@ -175,22 +171,17 @@ class DomCommands:
             command = copy.deepcopy(RuntimeCommands.CALL_FUNCTION_ON_TEMPLATE)
             command['params']['objectId'] = object_id
             command['params']['functionDeclaration'] = (
-                'function() {'
-                'return document.evaluate('
-                f'"{escaped_value}", this, null, '
-                'XPathResult.FIRST_ORDERED_NODE_TYPE, null'
-                ').singleNodeValue;'
-                '}'
+                Scripts.FIND_RELATIVE_XPATH_ELEMENT.replace(
+                    '{escaped_value}', escaped_value
+                )
             )
             command['params']['returnByValue'] = False
         else:
             command = copy.deepcopy(RuntimeCommands.EVALUATE_TEMPLATE)
             command['params']['expression'] = (
-                'var element = document.evaluate('
-                f'"{escaped_value}", document, null, '
-                'XPathResult.FIRST_ORDERED_NODE_TYPE, null'
-                ').singleNodeValue;'
-                'element;'
+                Scripts.FIND_XPATH_ELEMENT.replace(
+                    '{escaped_value}', escaped_value
+                )
             )
         return command
 
@@ -203,30 +194,16 @@ class DomCommands:
             command = copy.deepcopy(RuntimeCommands.CALL_FUNCTION_ON_TEMPLATE)
             command['params']['objectId'] = object_id
             command['params']['functionDeclaration'] = (
-                'function() {'
-                'var elements = document.evaluate('
-                f'"{escaped_value}", this, null, '
-                'XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null'
-                ');'
-                'var results = [];'
-                'for (var i = 0; i < elements.snapshotLength; i++) {'
-                'results.push(elements.snapshotItem(i));'
-                '}'
-                'return results;'
-                '}'
+                Scripts.FIND_RELATIVE_XPATH_ELEMENTS.replace(
+                    '{escaped_value}', escaped_value
+                )
             )
         else:
             command = copy.deepcopy(RuntimeCommands.EVALUATE_TEMPLATE)
             command['params']['expression'] = (
-                'var elements = document.evaluate('
-                f'"{escaped_value}", document, null, '
-                'XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null'
-                ');'
-                'var results = [];'
-                'for (var i = 0; i < elements.snapshotLength; i++) {'
-                'results.push(elements.snapshotItem(i));'
-                '}'
-                'results;'
+                Scripts.FIND_XPATH_ELEMENTS.replace(
+                    '{escaped_value}', escaped_value
+                )
             )
         return command
 

--- a/pydoll/commands/fetch.py
+++ b/pydoll/commands/fetch.py
@@ -43,9 +43,9 @@ class FetchCommands:
         request_id: str,
         url: str = '',
         method: str = '',
-        postData: str = '',
+        post_data: str = '',
         headers: dict = {},
-        interceptResponse: bool = False,
+        intercept_response: bool = False,
     ):
         """
         Creates a command to continue a paused fetch request.
@@ -76,13 +76,13 @@ class FetchCommands:
             continue_request_template['params']['url'] = url
         if method:
             continue_request_template['params']['method'] = method
-        if postData:
-            continue_request_template['params']['postData'] = postData
+        if post_data:
+            continue_request_template['params']['postData'] = post_data
         if headers:
             continue_request_template['params']['headers'] = headers
-        if interceptResponse:
+        if intercept_response:
             continue_request_template['params']['interceptResponse'] = (
-                interceptResponse
+                intercept_response
             )
         return continue_request_template
 
@@ -166,7 +166,7 @@ class FetchCommands:
         return enable_fetch_events_template
 
     @classmethod
-    def fail_request(cls, request_id: str, errorReason: str):
+    def fail_request(cls, request_id: str, error_reason: str):
         """
         Creates a command to simulate a failure in a fetch request.
 
@@ -182,18 +182,18 @@ class FetchCommands:
         """
         fail_request_template = cls.FAIL_REQUEST.copy()
         fail_request_template['params']['requestId'] = request_id
-        fail_request_template['params']['errorReason'] = errorReason
+        fail_request_template['params']['errorReason'] = error_reason
         return fail_request_template
 
     @classmethod
     def fulfill_request(  # noqa: PLR0913, PLR0917
         cls,
         request_id: str,
-        responseCode: int,
-        responseHeaders: dict = {},
-        binaryResponseHeaders: str = '',
+        response_code: int,
+        response_headers: dict = {},
+        binary_response_headers: str = '',
         body: str = '',
-        responsePhrase: str = '',
+        response_phrase: str = '',
     ):
         """
         Creates a command to fulfill a fetch request with a custom response.
@@ -218,21 +218,21 @@ class FetchCommands:
         """
         fulfill_request_template = cls.FULFILL_REQUEST.copy()
         fulfill_request_template['params']['requestId'] = request_id
-        if responseCode:
-            fulfill_request_template['params']['responseCode'] = responseCode
-        if responseHeaders:
+        if response_code:
+            fulfill_request_template['params']['responseCode'] = response_code
+        if response_headers:
             fulfill_request_template['params']['responseHeaders'] = (
-                responseHeaders
+                response_headers
             )
-        if binaryResponseHeaders:
+        if binary_response_headers:
             fulfill_request_template['params']['binaryResponseHeaders'] = (
-                binaryResponseHeaders
+                binary_response_headers
             )
         if body:
             fulfill_request_template['params']['body'] = body
-        if responsePhrase:
+        if response_phrase:
             fulfill_request_template['params']['responsePhrase'] = (
-                responsePhrase
+                response_phrase
             )
         return fulfill_request_template
 
@@ -258,11 +258,11 @@ class FetchCommands:
     @classmethod
     def continue_response(
         cls,
-        requestId: str,
-        responseCode: int = '',
-        responseHeaders: dict = {},
-        binaryResponseHeaders: str = '',
-        responsePhrase: str = '',
+        request_id: str,
+        response_code: int = '',
+        response_headers: dict = {},
+        binary_response_headers: str = '',
+        response_phrase: str = '',
     ):
         """
         Creates a command to continue a fetch response for an intercepted
@@ -288,19 +288,21 @@ class FetchCommands:
             dict: A command template for continuing the fetch response.
         """
         continue_response_template = cls.CONTINUE_RESPONSE.copy()
-        continue_response_template['params']['requestId'] = requestId
-        if responseCode:
-            continue_response_template['params']['responseCode'] = responseCode
-        if responseHeaders:
+        continue_response_template['params']['requestId'] = request_id
+        if response_code:
+            continue_response_template['params']['responseCode'] = (
+                response_code
+            )
+        if response_headers:
             continue_response_template['params']['responseHeaders'] = (
-                responseHeaders
+                response_headers
             )
-        if binaryResponseHeaders:
+        if binary_response_headers:
             continue_response_template['params']['binaryResponseHeaders'] = (
-                binaryResponseHeaders
+                binary_response_headers
             )
-        if responsePhrase:
+        if response_phrase:
             continue_response_template['params']['responsePhrase'] = (
-                responsePhrase
+                response_phrase
             )
         return continue_response_template

--- a/pydoll/commands/runtime.py
+++ b/pydoll/commands/runtime.py
@@ -40,6 +40,6 @@ class RuntimeCommands:
         command = copy.deepcopy(cls.EVALUATE_TEMPLATE)
         command['params'] = {
             'expression': expression,
-            'returnByValue': True,
+            'returnByValue': False,
         }
         return command

--- a/pydoll/commands/target.py
+++ b/pydoll/commands/target.py
@@ -7,21 +7,21 @@ class TargetCommands:
     GET_TARGET_INFO = {'method': 'Target.getTargetInfo', 'params': {}}
 
     @classmethod
-    def activate_target(cls, targetId: str) -> dict:
+    def activate_target(cls, target_id: str) -> dict:
         activate_target = cls.ATTACH_TO_TARGET.copy()
-        activate_target['params']['targetId'] = targetId
+        activate_target['params']['targetId'] = target_id
         return activate_target
 
     @classmethod
-    def attach_to_target(cls, targetId: str) -> dict:
+    def attach_to_target(cls, target_id: str) -> dict:
         attach_to_target = cls.ATTACH_TO_TARGET.copy()
-        attach_to_target['params']['targetId'] = targetId
+        attach_to_target['params']['targetId'] = target_id
         return attach_to_target
 
     @classmethod
-    def close_target(cls, targetId: str) -> dict:
+    def close_target(cls, target_id: str) -> dict:
         close_target = cls.CLOSE_TARGET.copy()
-        close_target['params']['targetId'] = targetId
+        close_target['params']['targetId'] = target_id
         return close_target
 
     @classmethod

--- a/pydoll/constants.py
+++ b/pydoll/constants.py
@@ -64,3 +64,62 @@ class Scripts:
         return JSON.stringify(this.getBoundingClientRect());
     }
     """
+
+    FIND_RELATIVE_XPATH_ELEMENT = """
+        function() {
+            return document.evaluate(
+                "{escaped_value}", this, null,
+                XPathResult.FIRST_ORDERED_NODE_TYPE, null
+            ).singleNodeValue;
+        }
+    """
+
+    FIND_XPATH_ELEMENT = """
+        var element = document.evaluate(
+            "{escaped_value}", document, null,
+            XPathResult.FIRST_ORDERED_NODE_TYPE, null
+        ).singleNodeValue;
+        element;
+    """
+
+    FIND_RELATIVE_XPATH_ELEMENTS = """
+        function() {
+            var elements = document.evaluate(
+                "{escaped_value}", this, null,
+                XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null
+            );
+            var results = [];
+            for (var i = 0; i < elements.snapshotLength; i++) {
+                results.push(elements.snapshotItem(i));
+            }
+            return results;
+        }
+    """
+
+    FIND_XPATH_ELEMENTS = """
+        var elements = document.evaluate(
+            "{escaped_value}", document, null,
+            XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null
+        );
+        var results = [];
+        for (var i = 0; i < elements.snapshotLength; i++) {
+            results.push(elements.snapshotItem(i));
+        }
+        results;
+    """
+
+    QUERY_SELECTOR = 'document.querySelector("{selector}");'
+
+    RELATIVE_QUERY_SELECTOR = """
+        function() {
+            return this.querySelector("{selector}");
+        }
+    """
+
+    QUERY_SELECTOR_ALL = 'document.querySelectorAll("{selector}");'
+
+    RELATIVE_QUERY_SELECTOR_ALL = """
+        function() {
+            return this.querySelectorAll("{selector}");
+        }
+    """

--- a/pydoll/element.py
+++ b/pydoll/element.py
@@ -115,7 +115,7 @@ class WebElement(FindElementsMixin):
         response = await self._execute_command(command)
         return response['result']['outerHTML']
 
-    async def get_bounds_by_js(self) -> list:
+    async def get_bounds_using_js(self) -> list:
         """
         Retrieves the bounding box of the element using JavaScript.
 
@@ -198,7 +198,7 @@ class WebElement(FindElementsMixin):
         command = DomCommands.scroll_into_view(object_id=self._object_id)
         await self._execute_command(command)
 
-    async def click(self):
+    async def click_using_js(self):
         if self._is_option_tag():
             return await self.click_option_tag()
 
@@ -218,7 +218,7 @@ class WebElement(FindElementsMixin):
                 'Element is not interactable.'
             )
 
-    async def realistic_click(self, x_offset: int = 0, y_offset: int = 0):
+    async def click(self, x_offset: int = 0, y_offset: int = 0):
         if not await self._is_element_visible():
             raise exceptions.ElementNotVisible(
                 'Element is not visible on the page.'
@@ -237,7 +237,7 @@ class WebElement(FindElementsMixin):
                 position_to_click[1] + y_offset,
             )
         except IndexError:
-            element_bounds = await self.get_bounds_by_js()
+            element_bounds = await self.get_bounds_using_js()
             element_bounds = json.loads(element_bounds)
             position_to_click = (
                 element_bounds['x'] + element_bounds['width'] / 2,

--- a/pydoll/mixins/find_elements.py
+++ b/pydoll/mixins/find_elements.py
@@ -3,7 +3,6 @@ import asyncio
 from pydoll import exceptions
 from pydoll.commands.dom import DomCommands
 from pydoll.commands.runtime import RuntimeCommands
-from pydoll.constants import By
 
 
 def create_web_element(*args, **kwargs):
@@ -40,21 +39,19 @@ class FindElementsMixin:
         """
         start_time = asyncio.get_event_loop().time()
         while True:
-            node_description = await self._get_node_description(by, value)
-            if node_description or (
-                asyncio.get_event_loop().time() - start_time > timeout
-            ):
-                break
+            try:
+                element = await self.find_element(by, value, raise_exc=False)
+                if element:
+                    return element
+            except exceptions.ElementNotFound:
+                pass
+
+            if asyncio.get_event_loop().time() - start_time > timeout:
+                if raise_exc:
+                    raise TimeoutError('Element not found')
+                return None
+
             await asyncio.sleep(0.5)
-
-        if not node_description:
-            if raise_exc:
-                raise TimeoutError('Element not found')
-            return None
-
-        return create_web_element(
-            node_description, self._connection_handler, by, value
-        )
 
     async def find_element(
         self, by: DomCommands.SelectorType, value: str, raise_exc: bool = True
@@ -115,7 +112,9 @@ class FindElementsMixin:
             command = DomCommands.find_elements(by, value, self._object_id)
         else:
             command = DomCommands.find_elements(by, value)
+
         response = await self._execute_command(command)
+
         if not response.get('result', {}).get('result', {}).get('objectId'):
             if raise_exc:
                 raise exceptions.ElementNotFound('Element not found')
@@ -151,107 +150,6 @@ class FindElementsMixin:
             )
         return elements
 
-    async def _get_nodes_description(self, by: str, value: str):
-        """
-        Executes a command to find elements on the page and returns their
-        descriptions.
-
-        Args:
-            by (str): The type of selector to use.
-            value (str): The value of the selector to use.
-
-        Returns:
-            list: The descriptions of the found nodes or an empty list if
-            not found.
-        """
-        if hasattr(self, '_node'):
-            root_node_id = self._node['nodeId']
-            object_id = self._node['objectId']
-        else:
-            root_node_id = await self._get_root_node_id()
-            object_id = ''
-
-        response = await self._execute_command(
-            DomCommands.find_elements(
-                by, value, node_id=root_node_id, object_id=object_id
-            )
-        )
-
-        if not response.get('result', {}):
-            return []
-
-        if by == By.XPATH:
-            if (
-                not response.get('result', {})
-                .get('result', {})
-                .get('objectId')
-            ):
-                return []
-
-            object_id = response['result']['result']['objectId']
-            query_response = await self._execute_command(
-                RuntimeCommands.get_properties(object_id=object_id)
-            )
-            response = []
-            for query in query_response['result']['result']:
-                query_value = query.get('value', {})
-                if query_value and query_value['type'] == 'object':
-                    response.append(query_value['objectId'])
-
-        nodes_description = await self._describe_nodes_based_on_response(
-            response, by
-        )
-        return nodes_description
-
-    async def _get_root_node_id(self):
-        """
-        Retrieves the root node ID of the current page's DOM.
-
-        Returns:
-            int: The unique ID of the root node in the current DOM.
-        """
-        response = await self._execute_command(DomCommands.dom_document())
-        return response['result']['root']['nodeId']
-
-    async def _describe_nodes_based_on_response(self, response: dict, by: str):
-        """
-        Describes nodes based on the response from finding the elements.
-
-        Args:
-            response (dict): The response containing the result of finding
-            the nodes.
-            by (str): The selector type used to find the nodes.
-
-        Returns:
-            list: A list of detailed descriptions of the nodes.
-        """
-        nodes_description = []
-        if by == By.XPATH:
-            for object_id in response:
-                try:
-                    node_description = await self._describe_node(
-                        object_id=object_id
-                    )
-                except KeyError:
-                    continue
-
-                node_id = await self._get_node_id_by_object_id(object_id)
-                node_description.update({
-                    'nodeId': node_id,
-                    'objectId': object_id,
-                })
-                nodes_description.append(node_description)
-        else:
-            for node_id in response['result']['nodeIds']:
-                node_description = await self._describe_node(node_id=node_id)
-                object_id = await self._get_object_id_by_node_id(node_id)
-                node_description.update({
-                    'nodeId': node_id,
-                    'objectId': object_id,
-                })
-                nodes_description.append(node_description)
-        return nodes_description
-
     async def _describe_node(self, object_id: str = '') -> dict:
         """
         Provides a detailed description of a specific node within the DOM.
@@ -266,36 +164,6 @@ class FindElementsMixin:
             DomCommands.describe_node(object_id=object_id)
         )
         return response['result']['node']
-
-    async def _get_object_id_by_node_id(self, node_id: int):
-        """
-        Retrieves the object ID of a node based on its node ID.
-
-        Args:
-            node_id (int): The unique ID of the node in the DOM.
-
-        Returns:
-            str: The object ID of the node.
-        """
-        response = await self._execute_command(
-            DomCommands.resolve_node(node_id)
-        )
-        return response['result']['object']['objectId']
-
-    async def _get_node_id_by_object_id(self, object_id: str):
-        """
-        Retrieves the node ID of a node based on its object ID.
-
-        Args:
-            object_id (str): The unique ID of the node in the DOM.
-
-        Returns:
-            int: The node ID of the node.
-        """
-        response = await self._execute_command(
-            DomCommands.request_node(object_id)
-        )
-        return response['result']['nodeId']
 
     async def _execute_command(self, command: dict) -> dict:
         """


### PR DESCRIPTION
The methods for finding elements were using the `node_id`, a DOM variable, to execute commands. With the goal of replacing the commands with relative searches, `object_id` is now used, which references a JavaScript object and can be utilized with greater flexibility.