### PR TITLE
fix: Get file extension from file path and changes use of reserved word 'format' to 'fmt'

### DIFF
--- a/pydoll/browser/page.py
+++ b/pydoll/browser/page.py
@@ -13,6 +13,7 @@ from pydoll.connection.connection import ConnectionHandler
 from pydoll.element import WebElement
 from pydoll.mixins.find_elements import FindElementsMixin
 from pydoll.utils import decode_image_to_bytes
+from pydoll.exceptions import InvalidExtension
 
 
 class Page(FindElementsMixin):  # noqa: PLR0904
@@ -200,7 +201,11 @@ class Page(FindElementsMixin):  # noqa: PLR0904
         Args:
             path (str): The file path to save the screenshot to.
         """
-        response = await self._execute_command(PageCommands.screenshot())
+        fmt = path.split('.')[-1]
+        if fmt not in ["jpeg", "jpg", "png"]:
+            raise InvalidExtension(f"{fmt} extension is not supported.")
+
+        response = await self._execute_command(PageCommands.screenshot(fmt=fmt))
         screenshot_b64 = response['result']['data'].encode('utf-8')
         screenshot_bytes = decode_image_to_bytes(screenshot_b64)
         async with aiofiles.open(path, 'wb') as file:

--- a/pydoll/browser/page.py
+++ b/pydoll/browser/page.py
@@ -11,9 +11,9 @@ from pydoll.commands.runtime import RuntimeCommands
 from pydoll.commands.storage import StorageCommands
 from pydoll.connection.connection import ConnectionHandler
 from pydoll.element import WebElement
+from pydoll.exceptions import InvalidFileExtension
 from pydoll.mixins.find_elements import FindElementsMixin
 from pydoll.utils import decode_image_to_bytes
-from pydoll.exceptions import InvalidFileExtension
 
 
 class Page(FindElementsMixin):  # noqa: PLR0904
@@ -202,10 +202,12 @@ class Page(FindElementsMixin):  # noqa: PLR0904
             path (str): The file path to save the screenshot to.
         """
         fmt = path.split('.')[-1]
-        if fmt not in ['jpeg', 'jpg', 'png']:
+        if fmt not in {'jpeg', 'jpg', 'png'}:
             raise InvalidFileExtension(f'{fmt} extension is not supported.')
 
-        response = await self._execute_command(PageCommands.screenshot(fmt=fmt))
+        response = await self._execute_command(
+            PageCommands.screenshot(fmt=fmt)
+        )
         screenshot_b64 = response['result']['data'].encode('utf-8')
         screenshot_bytes = decode_image_to_bytes(screenshot_b64)
         async with aiofiles.open(path, 'wb') as file:

--- a/pydoll/browser/page.py
+++ b/pydoll/browser/page.py
@@ -13,7 +13,7 @@ from pydoll.connection.connection import ConnectionHandler
 from pydoll.element import WebElement
 from pydoll.mixins.find_elements import FindElementsMixin
 from pydoll.utils import decode_image_to_bytes
-from pydoll.exceptions import InvalidExtension
+from pydoll.exceptions import InvalidFileExtension
 
 
 class Page(FindElementsMixin):  # noqa: PLR0904
@@ -202,8 +202,8 @@ class Page(FindElementsMixin):  # noqa: PLR0904
             path (str): The file path to save the screenshot to.
         """
         fmt = path.split('.')[-1]
-        if fmt not in ["jpeg", "jpg", "png"]:
-            raise InvalidExtension(f"{fmt} extension is not supported.")
+        if fmt not in ['jpeg', 'jpg', 'png']:
+            raise InvalidFileExtension(f'{fmt} extension is not supported.')
 
         response = await self._execute_command(PageCommands.screenshot(fmt=fmt))
         screenshot_b64 = response['result']['data'].encode('utf-8')

--- a/pydoll/commands/page.py
+++ b/pydoll/commands/page.py
@@ -71,13 +71,13 @@ class PageCommands:
 
     @classmethod
     def screenshot(
-        cls, format: str = 'jpeg', quality: int = 100, clip: dict = None
+        cls, fmt: str = 'jpeg', quality: int = 100, clip: dict = None
     ) -> dict:
         """
         Generates the command to capture a screenshot of the current page.
 
         Args:
-            format (str): The format of the image to be captured.
+            fmt (str): The format of the image to be captured.
                           Can be 'png' or 'jpeg'.
             quality (int): The quality of the image to be captured,
                            applicable only if the format is 'jpeg'.
@@ -89,7 +89,7 @@ class PageCommands:
                   containing the method and parameters for the screenshot.
         """
         command = cls.SCREENSHOT_TEMPLATE.copy()
-        command['params']['format'] = format
+        command['params']['format'] = fmt
         command['params']['quality'] = quality
         if clip:
             command['params']['clip'] = clip

--- a/pydoll/element.py
+++ b/pydoll/element.py
@@ -189,7 +189,7 @@ class WebElement(FindElementsMixin):
             'scale': 1,
         }
         screenshot = await self._connection_handler.execute_command(
-            PageCommands.screenshot(format='jpeg', clip=clip)
+            PageCommands.screenshot(fmt='jpeg', clip=clip)
         )
         async with aiofiles.open(path, 'wb') as file:
             image_bytes = decode_image_to_bytes(screenshot['result']['data'])

--- a/pydoll/exceptions.py
+++ b/pydoll/exceptions.py
@@ -80,3 +80,9 @@ class ElementNotInteractable(Exception):
 
     def __str__(self):
         return self.message
+
+class InvalidExtension(Exception):
+    message = 'The extension is not supported'
+
+    def __str__(self):
+        return self.message

--- a/pydoll/exceptions.py
+++ b/pydoll/exceptions.py
@@ -81,6 +81,7 @@ class ElementNotInteractable(Exception):
     def __str__(self):
         return self.message
 
+
 class InvalidFileExtension(Exception):
     message = 'The file extension provided is not supported'
 

--- a/pydoll/exceptions.py
+++ b/pydoll/exceptions.py
@@ -81,8 +81,8 @@ class ElementNotInteractable(Exception):
     def __str__(self):
         return self.message
 
-class InvalidExtension(Exception):
-    message = 'The extension is not supported'
+class InvalidFileExtension(Exception):
+    message = 'The file extension provided is not supported'
 
     def __str__(self):
         return self.message

--- a/tests/test_page_commands.py
+++ b/tests/test_page_commands.py
@@ -33,7 +33,7 @@ def test_screenshot_jpeg():
         },
     }
     assert (
-        PageCommands.screenshot(format='jpeg', quality=80) == expected_command
+        PageCommands.screenshot(fmt='jpeg', quality=80) == expected_command
     )
 
 
@@ -45,7 +45,7 @@ def test_screenshot_png():
             'quality': 100,
         },
     }
-    assert PageCommands.screenshot(format='png') == expected_command
+    assert PageCommands.screenshot(fmt='png') == expected_command
 
 
 def test_screenshot_with_clip():


### PR DESCRIPTION
I've run the following test code:

```
import asyncio
from pydoll.browser.chrome import Chrome
from pydoll.constants import By

async def main():
    # Start the browser with no additional webdriver configuration!
    async with Chrome() as browser:
        await browser.start()
        page = await browser.get_page()
        
        # Navigate through captcha-protected sites without worry
        await page.go_to('https://www.example.com')
        await page.get_screenshot('./ss.png')
        

asyncio.run(main())
```

It saved ss.png in the root directory, as expected, but when i tried to open it with the ubuntu's default image visualizer, i got the following error:

![image](https://github.com/user-attachments/assets/d9403956-e61b-4469-a03a-3bb00351fa10)

When i tried to change it to jpeg, it worked just fine, so i've implemented some logic to get the file extension from the file path given by the developer, i've also changed the use of the reserved word "format" to "fmt" to avoid problems.