### PR TITLE
fix: resolve issue #29 where browser path was not found on macOS

### DIFF
--- a/pydoll/browser/chrome.py
+++ b/pydoll/browser/chrome.py
@@ -1,4 +1,4 @@
-import os
+import platform
 
 from pydoll.browser.base import Browser
 from pydoll.browser.managers import BrowserOptionsManager
@@ -13,17 +13,22 @@ class Chrome(Browser):
 
     @staticmethod
     def _get_default_binary_location():
-        os_name = os.name
+        os_name = platform.system()
         match os_name:
-            case 'nt':
+            case 'Windows':
                 browser_path = (
                     r'C:\Program Files\Google\Chrome\Application\chrome.exe'
                 )
                 return BrowserOptionsManager.validate_browser_path(
                     browser_path
                 )
-            case 'posix':
+            case 'Linux':
                 browser_path = '/usr/bin/google-chrome'
+                return BrowserOptionsManager.validate_browser_path(
+                    browser_path
+                )
+            case 'Darwin':
+                browser_path = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
                 return BrowserOptionsManager.validate_browser_path(
                     browser_path
                 )

--- a/pydoll/browser/chrome.py
+++ b/pydoll/browser/chrome.py
@@ -14,23 +14,21 @@ class Chrome(Browser):
     @staticmethod
     def _get_default_binary_location():
         os_name = platform.system()
-        match os_name:
-            case 'Windows':
-                browser_path = (
-                    r'C:\Program Files\Google\Chrome\Application\chrome.exe'
-                )
-                return BrowserOptionsManager.validate_browser_path(
-                    browser_path
-                )
-            case 'Linux':
-                browser_path = '/usr/bin/google-chrome'
-                return BrowserOptionsManager.validate_browser_path(
-                    browser_path
-                )
-            case 'Darwin':
-                browser_path = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
-                return BrowserOptionsManager.validate_browser_path(
-                    browser_path
-                )
-            case _:
-                raise ValueError('Unsupported OS')
+        browser_paths = {
+            'Windows':
+                r'C:\Program Files\Google\Chrome\Application\chrome.exe',
+            'Linux':
+                '/usr/bin/google-chrome',
+            'Darwin':
+                '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+        }
+
+        browser_path = browser_paths.get(os_name)
+
+        if not browser_path:
+            raise ValueError('Unsupported OS')
+
+        return BrowserOptionsManager.validate_browser_path(
+            browser_path
+        )
+

--- a/pydoll/browser/chrome.py
+++ b/pydoll/browser/chrome.py
@@ -31,4 +31,3 @@ class Chrome(Browser):
         return BrowserOptionsManager.validate_browser_path(
             browser_path
         )
-


### PR DESCRIPTION
- Use platform.system() instead, os.name returns the same value whether it's Linux or macOS
- Unit test and refactor some code