### PR TITLE
fix: support multiple default Chrome paths on each OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@
     <img src="https://img.shields.io/github/issues/thalissonvs/pydoll/bug?label=Bugs&color=red" alt="GitHub bug issues">
     <img src="https://img.shields.io/github/issues/thalissonvs/pydoll/enhancement?label=Enhancements&color=purple" alt="GitHub enhancement issues">
 </p>
-
-Pydoll is an innovative Python library that's redefining Chromium browser automation! Unlike other solutions, Pydoll **completely eliminates the need for webdrivers**, providing a much more fluid and reliable automation experience.
-
 <p align="center">
     <a href="https://trendshift.io/repositories/13125" target="_blank"><img src="https://trendshift.io/api/badge/repositories/13125" alt="thalissonvs%2Fpydoll | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
+
+Pydoll is an innovative Python library that's redefining Chromium browser automation! Unlike other solutions, Pydoll **completely eliminates the need for webdrivers**, providing a much more fluid and reliable automation experience.
+
+
 
 ## ⭐ Extraordinary Features
 

--- a/pydoll/browser/chrome.py
+++ b/pydoll/browser/chrome.py
@@ -1,4 +1,3 @@
-import os
 import platform
 
 from pydoll.browser.base import Browser
@@ -15,21 +14,20 @@ class Chrome(Browser):
     @staticmethod
     def _get_default_binary_location():
         os_name = platform.system()
-
-        if os_name == 'Windows':
-            possible_paths = [
+        browser_paths = {
+            'Windows':
                 r'C:\Program Files\Google\Chrome\Application\chrome.exe',
-                r'C:\Program Files (x86)\Google\Chrome\Application\chrome.exe'
-            ]
-            for path in possible_paths:
-                if os.path.exists(path):
-                    return BrowserOptionsManager.validate_browser_path(path)
-            raise ValueError("Chrome not found in default Windows locations.")
-        elif os_name == 'Linux':
-            browser_path = '/usr/bin/google-chrome'
-        elif os_name == 'Darwin':
-            browser_path = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
-        else:
+            'Linux':
+                '/usr/bin/google-chrome',
+            'Darwin':
+                '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+        }
+
+        browser_path = browser_paths.get(os_name)
+
+        if not browser_path:
             raise ValueError('Unsupported OS')
 
-        return BrowserOptionsManager.validate_browser_path(browser_path)
+        return BrowserOptionsManager.validate_browser_path(
+            browser_path
+        )

--- a/pydoll/browser/chrome.py
+++ b/pydoll/browser/chrome.py
@@ -1,3 +1,4 @@
+import os
 import platform
 
 from pydoll.browser.base import Browser
@@ -7,20 +8,25 @@ from pydoll.browser.options import Options
 
 class Chrome(Browser):
     def __init__(
-        self, options: Options | None = None, connection_port: int = 9222
+            self, options: Options | None = None, connection_port: int = 9222
     ):
         super().__init__(options, connection_port)
 
     @staticmethod
     def _get_default_binary_location():
         os_name = platform.system()
+
         browser_paths = {
-            'Windows':
+            'Windows': [
                 r'C:\Program Files\Google\Chrome\Application\chrome.exe',
-            'Linux':
+                r'C:\Program Files (x86)\Google\Chrome\Application\chrome.exe',
+            ],
+            'Linux': [
                 '/usr/bin/google-chrome',
-            'Darwin':
-                '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+            ],
+            'Darwin': [
+                '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+            ]
         }
 
         browser_path = browser_paths.get(os_name)
@@ -28,6 +34,6 @@ class Chrome(Browser):
         if not browser_path:
             raise ValueError('Unsupported OS')
 
-        return BrowserOptionsManager.validate_browser_path(
+        return BrowserOptionsManager.validate_browser_paths(
             browser_path
         )

--- a/pydoll/browser/chrome.py
+++ b/pydoll/browser/chrome.py
@@ -1,4 +1,3 @@
-import os
 import platform
 
 from pydoll.browser.base import Browser

--- a/pydoll/browser/chrome.py
+++ b/pydoll/browser/chrome.py
@@ -1,3 +1,4 @@
+import os
 import platform
 
 from pydoll.browser.base import Browser
@@ -14,20 +15,21 @@ class Chrome(Browser):
     @staticmethod
     def _get_default_binary_location():
         os_name = platform.system()
-        browser_paths = {
-            'Windows':
+
+        if os_name == 'Windows':
+            possible_paths = [
                 r'C:\Program Files\Google\Chrome\Application\chrome.exe',
-            'Linux':
-                '/usr/bin/google-chrome',
-            'Darwin':
-                '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
-        }
-
-        browser_path = browser_paths.get(os_name)
-
-        if not browser_path:
+                r'C:\Program Files (x86)\Google\Chrome\Application\chrome.exe'
+            ]
+            for path in possible_paths:
+                if os.path.exists(path):
+                    return BrowserOptionsManager.validate_browser_path(path)
+            raise ValueError("Chrome not found in default Windows locations.")
+        elif os_name == 'Linux':
+            browser_path = '/usr/bin/google-chrome'
+        elif os_name == 'Darwin':
+            browser_path = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+        else:
             raise ValueError('Unsupported OS')
 
-        return BrowserOptionsManager.validate_browser_path(
-            browser_path
-        )
+        return BrowserOptionsManager.validate_browser_path(browser_path)

--- a/pydoll/browser/managers.py
+++ b/pydoll/browser/managers.py
@@ -139,16 +139,17 @@ class BrowserOptionsManager:
         options.arguments.append('--no-default-browser-check')
 
     @staticmethod
-    def validate_browser_path(path: str) -> str:
+    def validate_browser_paths(paths: list[str]) -> str:
         """
         Valida o caminho fornecido do navegador.
 
         Args:
-            path (str): O caminho do arquivo executável do navegador.
+            paths (list[str]): Lista de caminhos possíveis do navegador.
 
         Returns:
             str: O caminho do navegador validado.
         """
-        if not os.path.exists(path):
-            raise ValueError(f'Browser not found: {path}')
-        return path
+        for path in paths:
+            if os.path.exists(path) and os.access(path, os.X_OK):
+                return path
+        raise ValueError(f"No valid browser path found in: {paths}")

--- a/tests/test_browser_managers.py
+++ b/tests/test_browser_managers.py
@@ -139,7 +139,7 @@ def test_add_default_arguments():
 
 
 def test_validate_browser_paths_valid():
-    with patch('os.path.exists', return_value=True):
+    with patch('os.path.exists', return_value=True), patch('os.access', return_value=True):
         result = BrowserOptionsManager.validate_browser_paths(['/fake/path'])
         assert result == '/fake/path'
 
@@ -158,7 +158,10 @@ def test_validate_browser_paths_multiple():
             return True
         return False
 
-    with patch('os.path.exists', side_effect=fake_exists):
+    def fake_access(path, mode):
+        return path == '/second/fake/path'
+
+    with patch('os.path.exists', side_effect=fake_exists), patch('os.access', side_effect=fake_access):
         result = BrowserOptionsManager.validate_browser_paths([
             '/first/fake/path',
             '/second/fake/path'

--- a/tests/test_browser_managers.py
+++ b/tests/test_browser_managers.py
@@ -138,13 +138,29 @@ def test_add_default_arguments():
     assert '--no-default-browser-check' in options.arguments
 
 
-def test_validate_browser_path_valid():
+def test_validate_browser_paths_valid():
     with patch('os.path.exists', return_value=True):
-        result = BrowserOptionsManager.validate_browser_path('/fake/path')
+        result = BrowserOptionsManager.validate_browser_paths(['/fake/path'])
         assert result == '/fake/path'
 
 
-def test_validate_browser_path_invalid():
+def test_validate_browser_paths_invalid():
     with patch('os.path.exists', return_value=False):
         with pytest.raises(ValueError):
-            BrowserOptionsManager.validate_browser_path('/fake/path')
+            BrowserOptionsManager.validate_browser_paths(['/fake/path'])
+
+
+def test_validate_browser_paths_multiple():
+    def fake_exists(path):
+        if path == '/first/fake/path':
+            return False
+        elif path == '/second/fake/path':
+            return True
+        return False
+
+    with patch('os.path.exists', side_effect=fake_exists):
+        result = BrowserOptionsManager.validate_browser_paths([
+            '/first/fake/path',
+            '/second/fake/path'
+        ])
+        assert result == '/second/fake/path'

--- a/tests/test_browser_managers.py
+++ b/tests/test_browser_managers.py
@@ -152,11 +152,13 @@ def test_validate_browser_paths_invalid():
 
 def test_validate_browser_paths_multiple():
     def fake_exists(path):
-        if path == '/first/fake/path':
-            return False
-        elif path == '/second/fake/path':
-            return True
-        return False
+        match path:
+            case "/first/fake/path":
+                return False
+            case "/second/fake/path":
+                return True
+            case _:
+                return False
 
     def fake_access(path, mode):
         return path == '/second/fake/path'

--- a/tests/test_chrome.py
+++ b/tests/test_chrome.py
@@ -30,10 +30,10 @@ class ConcreteBrowser(Browser):
 @pytest_asyncio.fixture
 async def mock_browser():
     with patch.multiple(
-            Browser,
-            _get_default_binary_location=MagicMock(
-                return_value='/fake/path/to/browser'
-            ),
+        Browser,
+        _get_default_binary_location=MagicMock(
+            return_value='/fake/path/to/browser'
+        ),
     ), patch(
         'pydoll.browser.managers.BrowserProcessManager',
         autospec=True,

--- a/tests/test_chrome.py
+++ b/tests/test_chrome.py
@@ -30,10 +30,10 @@ class ConcreteBrowser(Browser):
 @pytest_asyncio.fixture
 async def mock_browser():
     with patch.multiple(
-        Browser,
-        _get_default_binary_location=MagicMock(
-            return_value='/fake/path/to/browser'
-        ),
+            Browser,
+            _get_default_binary_location=MagicMock(
+                return_value='/fake/path/to/browser'
+            ),
     ), patch(
         'pydoll.browser.managers.BrowserProcessManager',
         autospec=True,
@@ -360,21 +360,52 @@ async def test__get_valid_page_key_error(mock_browser):
         TargetCommands.create_target(''), timeout=60
     )
 
-@pytest.mark.parametrize('os_name, expected_browser_path', [
-    ('Windows', r'C:\Program Files\Google\Chrome\Application\chrome.exe'),
-    ('Linux', '/usr/bin/google-chrome'),
-    ('Darwin', '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome')
-])
+
+@pytest.mark.parametrize(
+    'os_name, expected_browser_paths, mock_return_value',
+    [
+        (
+                'Windows',
+                [
+                    r'C:\Program Files\Google\Chrome\Application\chrome.exe',
+                    r'C:\Program Files (x86)\Google\Chrome\Application\chrome.exe'
+                ],
+                r'C:\Program Files\Google\Chrome\Application\chrome.exe'
+        ),
+        (
+                'Linux',
+                ['/usr/bin/google-chrome'],
+                '/usr/bin/google-chrome'
+        ),
+        (
+                'Darwin',
+                ['/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'],
+                '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+        ),
+    ]
+)
 @patch('platform.system')
-@patch.object(BrowserOptionsManager, 'validate_browser_path')
-def test__get_default_binary_location(mock_validate_browser_path, mock_platform_system, os_name, expected_browser_path):
+@patch.object(BrowserOptionsManager, 'validate_browser_paths')
+def test__get_default_binary_location(
+        mock_validate_browser_paths,
+        mock_platform_system,
+        os_name,
+        expected_browser_paths,
+        mock_return_value
+):
     mock_platform_system.return_value = os_name
-    mock_validate_browser_path.return_value = expected_browser_path
-
+    mock_validate_browser_paths.return_value = mock_return_value
     path = Chrome._get_default_binary_location()
-    mock_validate_browser_path.assert_called_once_with(expected_browser_path)
+    mock_validate_browser_paths.assert_called_once_with(expected_browser_paths)
 
-    assert path == expected_browser_path
+    assert path == mock_return_value
+
+
+def test__get_default_binary_location_unsupported_os():
+    with patch('platform.system', return_value='SomethingElse'):
+        with pytest.raises(ValueError, match='Unsupported OS'):
+            Chrome._get_default_binary_location()
+
 
 @patch('platform.system')
 def test__get_default_binary_location_throws_exception_if_os_not_supported(mock_platform_system):


### PR DESCRIPTION
- Update _get_default_binary_location to check both "Program Files" and "Program Files (x86)" directories.
- Ensure that Chrome is correctly located regardless of its installation path.
- Raise an error if Chrome is not found in the default locations.