### PR TITLE
Handle case where Browser.WindowID is not found and improve error handling.

### DIFF
--- a/pydoll/browser/page.py
+++ b/pydoll/browser/page.py
@@ -32,6 +32,7 @@ class Page(FindElementsMixin):  # noqa: PLR0904
         self._network_events_enabled = False
         self._fetch_events_enabled = False
         self._dom_events_enabled = False
+        self._page_id = page_id
 
     @property
     def page_events_enabled(self) -> bool:
@@ -157,6 +158,7 @@ class Page(FindElementsMixin):  # noqa: PLR0904
         """
         if self._connection_handler.dialog:
             return True
+
         return False
 
     async def get_dialog_message(self) -> str:

--- a/pydoll/browser/page.py
+++ b/pydoll/browser/page.py
@@ -32,7 +32,6 @@ class Page(FindElementsMixin):  # noqa: PLR0904
         self._network_events_enabled = False
         self._fetch_events_enabled = False
         self._dom_events_enabled = False
-        self._page_id = page_id
 
     @property
     def page_events_enabled(self) -> bool:

--- a/pydoll/commands/browser.py
+++ b/pydoll/commands/browser.py
@@ -17,6 +17,10 @@ class BrowserCommands:
 
     CLOSE = {'method': 'Browser.close'}
     GET_WINDOW_ID = {'method': 'Browser.WindowID'}
+    GET_WINDOW_ID_BY_TARGET = {
+        'method': 'Browser.getWindowForTarget',
+        'params': {},
+    }
     SET_WINDOW_BOUNDS_TEMPLATE = {
         'method': 'Browser.setWindowBounds',
         'params': {},
@@ -61,6 +65,21 @@ class BrowserCommands:
             dict: The command to be sent to the browser.
         """
         return cls.GET_WINDOW_ID
+
+    @classmethod
+    def get_window_id_by_target(cls, target_id: str) -> dict:
+        """
+        Generates the command to get the ID of the current window.
+
+        Args:
+            target_id (str): The target_id to set for the window.
+
+        Returns:
+            dict: The command to be sent to the browser.
+        """
+        command = cls.GET_WINDOW_ID_BY_TARGET.copy()
+        command['params']['targetId'] = target_id
+        return command
 
     @classmethod
     def set_window_bounds(cls, window_id: int, bounds: dict) -> dict:

--- a/tests/test_browser_window.py
+++ b/tests/test_browser_window.py
@@ -1,0 +1,108 @@
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from pydoll.browser.base import Browser
+from pydoll.commands.browser import BrowserCommands
+
+
+class ConcreteBrowser(Browser):
+    def _get_default_binary_location(self) -> str:
+        return '/fake/path/to/browser'
+
+
+@pytest_asyncio.fixture
+async def mock_browser():
+    with patch.multiple(
+            Browser,
+            _get_default_binary_location=MagicMock(
+                return_value='/fake/path/to/browser'
+            ),
+    ), patch(
+        'pydoll.connection.connection.ConnectionHandler',
+        autospec=True,
+    ) as mock_conn_handler:
+        browser = ConcreteBrowser()
+        browser._connection_handler = mock_conn_handler.return_value
+        browser._connection_handler.execute_command = AsyncMock()
+        browser._connection_handler.register_callback = AsyncMock()
+
+        browser._pages = ['page1']
+
+        yield browser
+
+
+@pytest.mark.asyncio
+async def test_get_window_id_success(mock_browser):
+    mock_browser._connection_handler.execute_command.return_value = {
+        'result': {'windowId': 123}
+    }
+    result = await mock_browser.get_window_id()
+    assert result == 123
+
+
+@pytest.mark.asyncio
+async def test_get_window_id_with_error_and_retry(mock_browser):
+    mock_browser._execute_command = AsyncMock(side_effect=[
+        {'error': 'some error'},
+        {'result': {
+            'targetInfos': [{
+                'type': 'page',
+                'attached': True,
+                'targetId': 'target1'
+            }]
+        }},
+        {'result': {'windowId': 123}}
+    ])
+
+    result = await mock_browser.get_window_id()
+    assert result == 123
+
+
+@pytest.mark.asyncio
+async def test_get_window_id_failure(mock_browser):
+    mock_browser._connection_handler.execute_command.return_value = {
+        'error': 'some error'
+    }
+    mock_browser.get_targets = AsyncMock(return_value=[])
+    with pytest.raises(RuntimeError):
+        await mock_browser.get_window_id()
+
+
+@pytest.mark.asyncio
+async def test_get_valid_target_id_success(mock_browser):
+    pages = [{
+        'type': 'page',
+        'attached': True,
+        'targetId': 'target1'
+    }]
+    result = await mock_browser._get_valid_target_id(pages)
+    assert result == 'target1'
+
+
+@pytest.mark.asyncio
+async def test_get_valid_target_id_no_valid_page(mock_browser):
+    pages = []
+    with pytest.raises(RuntimeError, match="No valid attached browser page found."):
+        await mock_browser._get_valid_target_id(pages)
+
+
+@pytest.mark.asyncio
+async def test_get_valid_target_id_missing_target_id(mock_browser):
+    pages = [{
+        'type': 'page',
+        'attached': True,
+        'targetId': None
+    }]
+    with pytest.raises(RuntimeError, match="Valid page found but missing 'targetId'."):
+        await mock_browser._get_valid_target_id(pages)
+
+
+@pytest.mark.asyncio
+async def test_get_window_id_by_target(mock_browser):
+    expected_command = {
+        'method': 'Browser.getWindowForTarget',
+        'params': {
+            'targetId': 'target1',
+        },
+    }
+    assert BrowserCommands.get_window_id_by_target('target1') == expected_command


### PR DESCRIPTION
## Description
Improved error handling when retrieving Browser.WindowID. Now, if Browser.WindowID is not found, the code properly handles cases where pages are not attached or targetId is missing, preventing unexpected failures..

## Changes
Handle missing Browser.WindowID gracefully.
Added a new method that gets the window ID based on the target ID.
Added extra validation for missing targetId and improved error messages.

## Testing
Tests passing, test_browser and test_chrome.

This PR addresses issue https://github.com/thalissonvs/pydoll/issues/57 by fix bug Browser.WindowID wasn't found.
