### PR TITLE
Fix invalid browser events methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,9 +721,7 @@ from pydoll.events.page import PageEvents
 async def on_page_loaded(event):
     print(f"🌐 Navigating to: {event['params'].get('url')}")
 
-await browser.enable_page_events()  # Activates page events
-await browser.on(PageEvents.PAGE_LOADED, on_page_loaded) # Global listener!
-# Needs to be locally? Use the page.on method!
+await page.enable_page_events()
 await page.on(PageEvents.PAGE_LOADED, on_page_loaded)
 ```
 
@@ -735,20 +733,21 @@ from functools import partial
 async def on_page_loaded(page, event):
     print(f"📄 Page loaded: {await page.current_url}")
 
-await browser.on(PageEvents.PAGE_LOADED, partial(on_page_loaded, page))
+await page.enable_page_events()
+await page.on(PageEvents.PAGE_LOADED, partial(on_page_loaded, page))
 ```
 
 ##### `async enable_page_events() -> None`
-Track everything happening on your pages - loading states, navigation, DOM changes, and more! This works globally or locally. Just use the browser or the page instance to enable the events.
+Track everything happening on your pages - loading states, navigation, DOM changes, and more! This only locally. Just use  the page instance to enable the events.
 
 ```python
 # Enables page event monitoring
-await browser.enable_page_events() # global
+await page.enable_page_events()
 ```
 
 
 ##### `async enable_network_events() -> None`
-See all network activity in real-time - perfect for debugging or monitoring specific API calls!
+See all network activity in real-time - perfect for debugging or monitoring specific API calls! Only works in the page domain.
 
 ```python
 from pydoll.events.network import NetworkEvents
@@ -756,14 +755,14 @@ from pydoll.events.network import NetworkEvents
 async def on_request(event):
     print(f"🔄 Request to: {event['params']['request']['url']} will be sent")
 
-await browser.enable_network_events()
-await browser.on(NetworkEvents.REQUEST_WILL_BE_SENT, on_request)
+await page.enable_network_events()
+await page.on(NetworkEvents.REQUEST_WILL_BE_SENT, on_request)
 
 await page.go_to('https://www.google.com') # This will trigger the on_request callback
 ```
 
 ##### `async enable_dom_events() -> None`
-Watch the page structure change in real-time and react accordingly!
+Watch the page structure change in real-time and react accordingly! Only works on the page domain.
 
 ```python
 from pydoll.events.dom import DomEvents
@@ -771,8 +770,8 @@ from pydoll.events.dom import DomEvents
 async def on_dom_event(event):
     print(f"🔄 The DOM has been updated!")
 
-await browser.enable_dom_events()
-await browser.on(DomEvents.DOCUMENT_UPDATED, on_dom_event)
+await page.enable_dom_events()
+await page.on(DomEvents.DOCUMENT_UPDATED, on_dom_event)
 ```
 
 ##### `async enable_fetch_events(handle_auth_requests: bool = False, resource_type: str = '') -> None`
@@ -803,6 +802,8 @@ async def interceptor(page, event):
 
 await browser.enable_fetch_events(resource_type='xhr') # only intercept XHR requests
 await browser.on(FetchEvents.REQUEST_PAUSED, partial(interceptor, page))
+
+await page.enable_fetch_events() # also works in the page domain!
 ```
 
 With this power, you can transform your automation into something truly intelligent!
@@ -813,6 +814,7 @@ Turn off request interception when you're done.
 ```python
 # Disables request interception
 await browser.disable_fetch_events()
+await page.disable_fetch_events()
 ```
 
 ### Concurrent Scraping

--- a/pydoll/commands/dom.py
+++ b/pydoll/commands/dom.py
@@ -24,6 +24,7 @@ class DomCommands:
     ]
 
     ENABLE = {'method': 'DOM.enable'}
+    DISABLE = {'method': 'DOM.disable'}
     DOM_DOCUMENT = {'method': 'DOM.getDocument'}
     DESCRIBE_NODE_TEMPLATE = {'method': 'DOM.describeNode', 'params': {}}
     FIND_ELEMENT_TEMPLATE = {'method': 'DOM.querySelector', 'params': {}}
@@ -137,6 +138,13 @@ class DomCommands:
             dict: The CDP command to enable the DOM domain.
         """
         return cls.ENABLE
+
+    @classmethod
+    def disable_dom_events(cls) -> dict:
+        """
+        Generates a command to disable the DOM domain in CDP.
+        """
+        return cls.DISABLE
 
     @classmethod
     def get_current_url(cls) -> dict:

--- a/pydoll/events/page.py
+++ b/pydoll/events/page.py
@@ -142,3 +142,22 @@ class PageEvents:
     This event is useful for tracking changes in the document state, such as
     anchor links or in-page navigation, without requiring a full page reload.
     """
+
+    ALL_EVENTS = [
+        PAGE_LOADED,
+        DOM_CONTENT_LOADED,
+        FILE_CHOOSER_OPENED,
+        FRAME_ATTACHED,
+        FRAME_DETACHED,
+        FRAME_NAVIGATED,
+        JS_DIALOG_CLOSED,
+        JS_DIALOG_OPENING,
+        LIFECYCLE_EVENT,
+        WINDOW_OPENED,
+        DOCUMENT_OPENED,
+        FRAME_STARTED_LOADING,
+        FRAME_STOPPED_LOADING,
+        DOWNLOAD_PROGRESS,
+        DOWNLOAD_WILL_BEGIN,
+        NAVIGATED_WITHIN_DOCUMENT,
+    ]

--- a/pydoll/exceptions.py
+++ b/pydoll/exceptions.py
@@ -87,3 +87,13 @@ class InvalidFileExtension(Exception):
 
     def __str__(self):
         return self.message
+
+
+class EventNotSupported(Exception):
+    message = 'The event is not supported'
+
+    def __init__(self, message: str = ''):
+        self.message = message or self.message
+
+    def __str__(self):
+        return self.message

--- a/tests/test_chrome.py
+++ b/tests/test_chrome.py
@@ -246,7 +246,6 @@ async def test_context_manager(mock_browser):
 
 @pytest.mark.asyncio
 async def test_enable_events(mock_browser):
-    # O método enable_page_events foi removido, então não testamos mais
     await mock_browser.enable_fetch_events(
         handle_auth_requests=True, resource_type='XHR'
     )
@@ -408,21 +407,18 @@ async def test_register_event_callback_page_event():
     browser = ConcreteBrowser()
     browser._connection_handler = mock_conn_handler
     
-    # Testando que eventos de página não são permitidos no Browser
     with pytest.raises(exceptions.EventNotSupported) as excinfo:
         await browser.on(
             PageEvents.PAGE_LOADED, AsyncMock()
         )
     assert 'Page events are not supported in the browser domain' in str(excinfo.value)
     
-    # Testando para outro evento de página também
     with pytest.raises(exceptions.EventNotSupported) as excinfo:
         await browser.on(
             PageEvents.DOM_CONTENT_LOADED, AsyncMock()
         )
     assert 'Page events are not supported in the browser domain' in str(excinfo.value)
     
-    # Testando com evento que está na lista ALL_EVENTS
     for event in PageEvents.ALL_EVENTS:
         with pytest.raises(exceptions.EventNotSupported):
             await browser.on(event, AsyncMock())

--- a/tests/test_chrome.py
+++ b/tests/test_chrome.py
@@ -17,11 +17,10 @@ from pydoll.commands import (
     DomCommands,
     FetchCommands,
     NetworkCommands,
-    PageCommands,
     StorageCommands,
     TargetCommands,
 )
-from pydoll.events import FetchEvents
+from pydoll.events import FetchEvents, PageEvents
 
 class ConcreteBrowser(Browser):
     def _get_default_binary_location(self) -> str:
@@ -247,21 +246,7 @@ async def test_context_manager(mock_browser):
 
 @pytest.mark.asyncio
 async def test_enable_events(mock_browser):
-    await mock_browser.enable_page_events()
-    mock_browser._connection_handler.execute_command.assert_called_with(
-        PageCommands.enable_page()
-    )
-
-    await mock_browser.enable_network_events()
-    mock_browser._connection_handler.execute_command.assert_called_with(
-        NetworkCommands.enable_network_events()
-    )
-
-    await mock_browser.enable_dom_events()
-    mock_browser._connection_handler.execute_command.assert_called_with(
-        DomCommands.enable_dom_events()
-    )
-
+    # O método enable_page_events foi removido, então não testamos mais
     await mock_browser.enable_fetch_events(
         handle_auth_requests=True, resource_type='XHR'
     )
@@ -276,6 +261,7 @@ async def test_disable_events(mock_browser):
     mock_browser._connection_handler.execute_command.assert_called_with(
         FetchCommands.disable_fetch_events()
     )
+
 
 
 @pytest.mark.asyncio
@@ -414,3 +400,29 @@ def test__get_default_binary_location_throws_exception_if_os_not_supported(mock_
 
     with pytest.raises(ValueError, match="Unsupported OS"):
         Chrome._get_default_binary_location()
+
+
+@pytest.mark.asyncio
+async def test_register_event_callback_page_event():
+    mock_conn_handler = AsyncMock()
+    browser = ConcreteBrowser()
+    browser._connection_handler = mock_conn_handler
+    
+    # Testando que eventos de página não são permitidos no Browser
+    with pytest.raises(exceptions.EventNotSupported) as excinfo:
+        await browser.on(
+            PageEvents.PAGE_LOADED, AsyncMock()
+        )
+    assert 'Page events are not supported in the browser domain' in str(excinfo.value)
+    
+    # Testando para outro evento de página também
+    with pytest.raises(exceptions.EventNotSupported) as excinfo:
+        await browser.on(
+            PageEvents.DOM_CONTENT_LOADED, AsyncMock()
+        )
+    assert 'Page events are not supported in the browser domain' in str(excinfo.value)
+    
+    # Testando com evento que está na lista ALL_EVENTS
+    for event in PageEvents.ALL_EVENTS:
+        with pytest.raises(exceptions.EventNotSupported):
+            await browser.on(event, AsyncMock())

--- a/tests/test_dom_commands.py
+++ b/tests/test_dom_commands.py
@@ -22,6 +22,14 @@ def test_enable_dom_events():
     )
 
 
+def test_disable_dom_events():
+    expected = {'method': 'DOM.disable'}
+    result = DomCommands.disable_dom_events()
+    assert result == expected, (
+        'The disable_dom_events method did not return the expected dictionary.'
+    )
+
+
 def test_dom_document():
     expected = {'method': 'DOM.getDocument'}
     result = DomCommands.dom_document()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -85,3 +85,23 @@ def test_page_events():
     assert PageEvents.WINDOW_OPENED == 'Page.windowOpen'
     assert PageEvents.DOCUMENT_OPENED == 'Page.documentOpened'
     assert PageEvents.FILE_CHOOSER_OPENED == 'Page.fileChooserOpened'
+
+
+def test_page_events_all_events():
+    assert PageEvents.PAGE_LOADED in PageEvents.ALL_EVENTS
+    assert PageEvents.DOM_CONTENT_LOADED in PageEvents.ALL_EVENTS
+    assert PageEvents.FILE_CHOOSER_OPENED in PageEvents.ALL_EVENTS
+    assert PageEvents.FRAME_ATTACHED in PageEvents.ALL_EVENTS
+    assert PageEvents.FRAME_DETACHED in PageEvents.ALL_EVENTS
+    assert PageEvents.FRAME_NAVIGATED in PageEvents.ALL_EVENTS
+    assert PageEvents.JS_DIALOG_CLOSED in PageEvents.ALL_EVENTS
+    assert PageEvents.JS_DIALOG_OPENING in PageEvents.ALL_EVENTS
+    assert PageEvents.LIFECYCLE_EVENT in PageEvents.ALL_EVENTS
+    assert PageEvents.WINDOW_OPENED in PageEvents.ALL_EVENTS
+    assert PageEvents.DOCUMENT_OPENED in PageEvents.ALL_EVENTS
+    assert PageEvents.FRAME_STARTED_LOADING in PageEvents.ALL_EVENTS
+    assert PageEvents.FRAME_STOPPED_LOADING in PageEvents.ALL_EVENTS
+    assert PageEvents.DOWNLOAD_PROGRESS in PageEvents.ALL_EVENTS
+    assert PageEvents.DOWNLOAD_WILL_BEGIN in PageEvents.ALL_EVENTS
+    assert PageEvents.NAVIGATED_WITHIN_DOCUMENT in PageEvents.ALL_EVENTS
+    assert len(PageEvents.ALL_EVENTS) == 16


### PR DESCRIPTION
### **PR Type**
Bug fix, Documentation, Tests


___

### **Description**
- Removed support for browser-level page, network, and DOM events.

- Added validation to prevent unsupported page events in the browser domain.

- Updated documentation to reflect changes in event handling.

- Enhanced tests to validate new behavior and ensure unsupported events raise exceptions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>base.py</strong><dd><code>Removed browser-level event methods and added validation for </code><br><code>unsupported events.</code></dd></td>
  <td><a href="https://github.com/thalissonvs/pydoll/pull/80/files#diff-8acf1bffca54e9c1d1e2d38663264dd28174b7f3d430244ccfbd079ce2bf82e2">+9/-76</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>dom.py</strong><dd><code>Added support for disabling DOM events in the DOM commands.</code></dd></td>
  <td><a href="https://github.com/thalissonvs/pydoll/pull/80/files#diff-33b848c65a7f45f57dc1456695ce1d3ba2c0a7a3c387ca9b64e153ddfe01d089">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.py</strong><dd><code>Introduced `ALL_EVENTS` list for page events.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thalissonvs/pydoll/pull/80/files#diff-4805ca9ebed21e5f5b57941c36ccac246081444833edbc01eced72333ff51ad2">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>exceptions.py</strong><dd><code>Added `EventNotSupported` exception for unsupported events.</code></dd></td>
  <td><a href="https://github.com/thalissonvs/pydoll/pull/80/files#diff-cec39760bd8bd80cbdd1d88698205525e737394e3d4877ae49337154a65e8a8e">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_chrome.py</strong><dd><code>Updated tests to validate unsupported browser-level events.</code></dd></td>
  <td><a href="https://github.com/thalissonvs/pydoll/pull/80/files#diff-ead81ac909319e84ef2b5eeefdbf5c6d2b115c3eef2a6daee77d99cf95a8a1bc">+29/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_dom_commands.py</strong><dd><code>Added test for disabling DOM events.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thalissonvs/pydoll/pull/80/files#diff-caa922f51c255401ad0f492e81ce12936dd3d3e79a7a8fef61c0df69907c5f53">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_events.py</strong><dd><code>Added tests for `ALL_EVENTS` in page events.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/thalissonvs/pydoll/pull/80/files#diff-17a9b99a7b95f217c0c8d0f8d0c9d852368eb8e2e14883d26b443483e1b7597f">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Updated documentation to reflect event handling changes.</code>&nbsp; </dd></td>
  <td><a href="https://github.com/thalissonvs/pydoll/pull/80/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+14/-12</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>