### PR TITLE
Validate browser path refers to file not directory

### DIFF
--- a/pydoll/utils.py
+++ b/pydoll/utils.py
@@ -159,7 +159,7 @@ def validate_browser_paths(paths: list[str]) -> str:
         InvalidBrowserPath: If the browser executable is not found at the path.
     """
     for path in paths:
-        if os.path.exists(path) and os.access(path, os.X_OK):
+        if os.path.isfile(path) and os.access(path, os.X_OK):
             return path
     raise InvalidBrowserPath(f'No valid browser path found in: {paths}')
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -206,6 +206,17 @@ class TestUtils:
             with pytest.raises(exceptions.InvalidBrowserPath):
                 validate_browser_paths([non_executable])
 
+    @pytest.mark.skipif(sys.platform.startswith('win'), reason='No executable bit on NTFS on Windows')
+    def test_validate_browser_paths_directory_instead_of_file(self):
+        """
+        Test validate_browser_paths with a directory path.
+        Verifies that directories are not treated as valid executables even if they have execute permission.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.chmod(temp_dir, 0o755)
+            with pytest.raises(exceptions.InvalidBrowserPath):
+                validate_browser_paths([temp_dir])
+
     def test_validate_browser_paths_empty_list(self):
         """
         Test validate_browser_paths with empty path list.


### PR DESCRIPTION
## Summary
- ensure `validate_browser_paths` ignores directories even if they are executable
- add test for directory path validation

## Testing
- `/usr/bin/python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_6895e72c64c48320a083178045194404