### PR TITLE
Update chrome.py with default chrome path for AUR installs

### DIFF
--- a/pydoll/browser/chromium/chrome.py
+++ b/pydoll/browser/chromium/chrome.py
@@ -47,6 +47,7 @@ class Chrome(Browser):
             ],
             'Linux': [
                 '/usr/bin/google-chrome',
+                '/usr/bin/google-chrome-stable',
             ],
             'Darwin': [
                 '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',

--- a/tests/test_browser/test_browser_base.py
+++ b/tests/test_browser/test_browser_base.py
@@ -398,7 +398,7 @@ def test__is_valid_tab_not_a_tab(mock_browser):
             ],
             r'C:\Program Files\Google\Chrome\Application\chrome.exe',
         ),
-        ('Linux', ['/usr/bin/google-chrome'], '/usr/bin/google-chrome'),
+        ('Linux', ['/usr/bin/google-chrome', '/usr/bin/google-chrome-stable'], '/usr/bin/google-chrome'),
         (
             'Darwin',
             ['/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'],

--- a/tests/test_browser/test_browser_chrome.py
+++ b/tests/test_browser/test_browser_chrome.py
@@ -131,7 +131,7 @@ class TestChromeDefaultBinaryLocation:
             ),
             (
                 'Linux',
-                ['/usr/bin/google-chrome']
+                ['/usr/bin/google-chrome', '/usr/bin/google-chrome-stable']
             ),
             (
                 'Darwin',


### PR DESCRIPTION

# Pull Request

## Description
Add `google-chrome-stable` to browser_paths list to support Arch Linux. This is the default path when using AUR Google Chrome package (https://aur.archlinux.org/packages/google-chrome)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Performance improvement
- [ ] Tests (adding missing tests or correcting existing tests)
- [ ] Build or CI/CD related changes

## How Has This Been Tested?
Ran samples from documentation on CachyOS.

## Testing Checklist
<!-- Check the testing aspects that apply to your change -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

## Implementation Details
It's a one liner.

## API Changes
N/A

## Additional Info
N/A