### PR TITLE
fix: filter Symbol properties from element query results

### DIFF
--- a/pydoll/elements/mixins/find_elements_mixin.py
+++ b/pydoll/elements/mixins/find_elements_mixin.py
@@ -463,9 +463,9 @@ class FindElementsMixin:
         )
         response: list[str] = []
         for query in query_response['result']['result']:
-            query_value = query.get('value', {})
-            if query_value and query_value['type'] == 'object':
-                response.append(query_value['objectId'])
+            if not (query['name'].isdigit() and 'objectId' in query['value']):
+                continue
+            response.append(query['value']['objectId'])
 
         elements = []
         for object_id in response:

--- a/tests/test_web_element.py
+++ b/tests/test_web_element.py
@@ -1358,8 +1358,8 @@ class TestWebElementFindMethods:
         properties_response = {
             'result': {
                 'result': [
-                    {'value': {'type': 'object', 'objectId': 'child-1'}},
-                    {'value': {'type': 'object', 'objectId': 'child-2'}},
+                    {'name': '0', 'value': {'type': 'object', 'objectId': 'child-1'}},
+                    {'name': '1', 'value': {'type': 'object', 'objectId': 'child-2'}},
                 ]
             }
         }


### PR DESCRIPTION
<!-- 
Please choose the appropriate PR template for your change:

For bug fixes: .github/PULL_REQUEST_TEMPLATE/bug_fix.md
For refactoring: .github/PULL_REQUEST_TEMPLATE/refactoring.md
For releases: .github/PULL_REQUEST_TEMPLATE/release.md

Or use this general template for other types of changes.
-->

# Pull Request

## Description
This PR fixes `_find_elements` returning one extra element. The method now filters properties by numeric index, matching the existing pattern in `web_element.py`.

## Related Issue(s)
Fixes #335.

## Type of Change
<!-- Check the appropriate options that apply to this PR -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Performance improvement
- [ ] Tests (adding missing tests or correcting existing tests)
- [ ] Build or CI/CD related changes

## How Has This Been Tested?
Added a test that mocks `Runtime.getProperties` response containing `Symbol(Symbol.unscopables)` alongside valid elements, verifying only numeric-indexed properties are returned. Also tested against `example.com`.

## Testing Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

## Screenshots

## Implementation Details

## API Changes

## Additional Info

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `poetry run task lint` and fixed any issues
- [x] I have run `poetry run task test` and all tests pass
- [x] My commits follow the [conventional commits](https://www.conventionalcommits.org/) style 