### PR TITLE
fix(browser): support secure websocket connections

### DIFF
--- a/pydoll/browser/chromium/base.py
+++ b/pydoll/browser/chromium/base.py
@@ -906,9 +906,9 @@ class Browser(ABC):  # noqa: PLR0904
     def _validate_ws_address(ws_address: str):
         """Validate WebSocket address."""
         min_slashes = 4
-        if not ws_address.startswith('ws://'):
-            logger.error('Invalid WebSocket address: missing ws:// prefix')
-            raise InvalidWebSocketAddress('WebSocket address must start with ws://')
+        if not ws_address.startswith(('ws://', 'wss://')):
+            logger.error('Invalid WebSocket address: missing ws:// or wss:// prefix')
+            raise InvalidWebSocketAddress('WebSocket address must start with ws:// or wss://')
         if len(ws_address.split('/')) < min_slashes:
             logger.error('Invalid WebSocket address: not enough slashes')
             raise InvalidWebSocketAddress(

--- a/tests/test_browser/test_browser_base.py
+++ b/tests/test_browser/test_browser_base.py
@@ -372,9 +372,22 @@ def test__validate_ws_address_raises_on_invalid_scheme():
         Browser._validate_ws_address('http://localhost:9222/devtools/browser/abc')
 
 
+def test__validate_ws_address_accepts_ws_scheme():
+    Browser._validate_ws_address('ws://localhost:9222/devtools/browser/abc')
+
+
+def test__validate_ws_address_accepts_wss_scheme():
+    Browser._validate_ws_address('wss://connect.browserbase.com/devtools/browser/abc')
+
+
 def test__validate_ws_address_raises_on_insufficient_slashes():
     with pytest.raises(InvalidWebSocketAddress):
         Browser._validate_ws_address('ws://localhost')
+
+
+def test__validate_ws_address_raises_on_insufficient_slashes_wss():
+    with pytest.raises(InvalidWebSocketAddress):
+        Browser._validate_ws_address('wss://localhost')
 
 
 def test__get_tab_ws_address_raises_when_ws_not_set(mock_browser):
@@ -387,6 +400,12 @@ def test__get_tab_ws_address_preserves_query_and_fragment(mock_browser):
     mock_browser._ws_address = 'ws://host:9222/devtools/browser/abc?token=XYZ#frag'
     result = mock_browser._get_tab_ws_address('tab1')
     assert result == 'ws://host:9222/devtools/page/tab1?token=XYZ#frag'
+
+
+def test__get_tab_ws_address_preserves_wss_scheme(mock_browser):
+    mock_browser._ws_address = 'wss://connect.browserbase.com/devtools/browser/abc?token=secret'
+    result = mock_browser._get_tab_ws_address('tab1')
+    assert result == 'wss://connect.browserbase.com/devtools/page/tab1?token=secret'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Pull Request

## Description

The `Chrome.connect()` method was rejecting `wss://` URLs with an `InvalidWebSocketAddress` error. This broke compatibility with hosted CDP providers like Browserbase that use secure websocket connections. Updated the validation to accept both `ws://` and `wss://` schemes.

## Related Issue(s)

Fixes #338

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Performance improvement
- [ ] Tests (adding missing tests or correcting existing tests)
- [ ] Build or CI/CD related changes

## How Has This Been Tested?

```python
from pydoll.browser.chromium.base import Browser

# ws:// still works
Browser._validate_ws_address('ws://localhost:9222/devtools/browser/abc')

# wss:// now works (was failing before)
Browser._validate_ws_address('wss://connect.browserbase.com/devtools/browser/abc')

# invalid schemes still rejected
Browser._validate_ws_address('http://localhost:9222/devtools/browser/abc')  # raises InvalidWebSocketAddress
```

## Testing Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All existing tests pass

## Screenshots

N/A

## Implementation Details

## API Changes

None. This is backwards compatible - existing `ws://` URLs continue to work.

## Additional Info

The downstream code (`_get_tab_ws_address`) already handled `wss://` correctly via `urlsplit`, so this was just an oversight in the validation check.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `poetry run task lint` and fixed any issues
- [x] I have run `poetry run task test` and all tests pass
- [x] My commits follow the [conventional commits](https://www.conventionalcommits.org/) style