### PR TITLE
fix: humanized scroll overshoot correction causes infinite loop

### DIFF
--- a/pydoll/interactions/scroll.py
+++ b/pydoll/interactions/scroll.py
@@ -281,7 +281,10 @@ class Scroll:
         timing = self._timing
         scrolled = 0.0
 
-        correction_velocity = random.uniform(200, 400)
+        min_correction_velocity = (distance * (0.15)) / timing.frame_interval
+        correction_velocity = random.uniform(
+            max(200, min_correction_velocity), max(400, min_correction_velocity * 1.5)
+        )
 
         while scrolled < distance:
             frame_delta = correction_velocity * timing.frame_interval


### PR DESCRIPTION
# Bug Fix Pull Request
I've been using pydoll in numerous projects. In the recent one I tried using the humanized scrolling feature. The scroll expressions randomly blocked the code without ever ending. And it was happening a notable amount of times. Maybe four or five times out of every ten runs of my code. At first I thought it was some kind of async blocking issue because it looked like it. With some debugging, I realized the problem was within the _scroll_correction function. Which contained a loop that that never stopped.

Here is my code (This is the line that blocks due to infinite loop):
<img width="921" height="270" alt="image" src="https://github.com/user-attachments/assets/c9e933cd-1da2-434f-b68b-21274edf359a" />

The context of the code does not matter. With the given values, This code must fail on any web page. It does according to my tests.

P.S. This is a great and useful tool. Kudos to the maintainers!
## Bug Description
The overshoot scroll correction function has a loop that expects the covered distance always reaches the target distance in some iteration of the loop. That is not the case. A randomly sampled initial velocity could be too low to cover the correction distance. This will ultimately cause an infinite loop. The initial velocity must be derived from the distance to guarantee that convergence. This commit is expected to solve this problem by taking the distance into account when generating a random initial velocity.

## Root Cause
The while loop inside the _scroll_correction function.

## Solution
Ensure that the while loop termination condition is always met.

## Verification Steps
Excuse the lovely handwriting, but this will guarantee that the loop always terminates (This PR implements the minimum required velocity for a given distance).
![CamScanner 02-22-2026 15 08](https://github.com/user-attachments/assets/934e4a26-23a1-450f-b28e-2190762245a0)



## Impact
Medium (might affect closely related functionality)

## Backwards Compatibility
This change is fully backward compatible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted internal scroll correction velocity calculation to use distance/frame-interval-derived bounds (replaces prior fixed bounds); internal logic only.

* **Notes**
  * No changes to public APIs, method signatures, control flow, or error handling.
  * No user-visible changes; existing behavior and integrations remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->