### PR TITLE
fix: update broken deep-dive links in docs feature pages

### DIFF
--- a/docs/en/features/core-concepts.md
+++ b/docs/en/features/core-concepts.md
@@ -59,7 +59,7 @@ Behind the scenes, `browser.start()` does the following:
 4. **Returns a Tab instance** ready for automation
 
 !!! info "Want to Know More?"
-    For technical details on how the browser process is managed internally, see the [Browser Domain](../../deep-dive/browser-domain.md#browser-process-manager) deep dive.
+    For technical details on how the browser process is managed internally, see the [Browser Domain](../../deep-dive/architecture/browser-domain.md#browser-process-manager) deep dive.
 
 ### Benefits You'll Notice
 
@@ -97,14 +97,14 @@ The Chrome DevTools Protocol isn't just for Pydoll; it's the same protocol that 
 - **Active development**: Google maintains and evolves CDP continuously
 
 !!! tip "Deep Dive: Understanding CDP"
-    For a comprehensive understanding of how CDP works and why it's superior to WebDriver, see our [Chrome DevTools Protocol](../../deep-dive/cdp.md) deep dive.
+    For a comprehensive understanding of how CDP works and why it's superior to WebDriver, see our [Chrome DevTools Protocol](../../deep-dive/fundamentals/cdp.md) deep dive.
 
 ## Async-First Architecture
 
 Pydoll isn't just async-compatible; it's designed from the ground up to leverage Python's `asyncio` framework. This isn't a checkbox feature; it's fundamental to how Pydoll achieves high performance.
 
 !!! info "New to Async Programming?"
-    If you're not familiar with Python's `async`/`await` syntax or asyncio concepts, we strongly recommend reading our [Understanding Async/Await](../../deep-dive/connection-layer.md#understanding-asyncawait) guide first. It explains the fundamentals with practical examples that will help you understand how Pydoll's async architecture works and why it's so powerful for browser automation.
+    If you're not familiar with Python's `async`/`await` syntax or asyncio concepts, we strongly recommend reading our [Understanding Async/Await](../../deep-dive/fundamentals/connection-layer.md#understanding-asyncawait) guide first. It explains the fundamentals with practical examples that will help you understand how Pydoll's async architecture works and why it's so powerful for browser automation.
 
 ### Why Async Matters for Browser Automation
 
@@ -190,7 +190,7 @@ async with tab.expect_download(keep_file_at='/downloads') as dl:
 ```
 
 !!! tip "Deep Dive"
-    Want to understand how async operations work under the hood? Check out the [Connection Layer](../../deep-dive/connection-layer.md) deep dive for implementation details.
+    Want to understand how async operations work under the hood? Check out the [Connection Layer](../../deep-dive/fundamentals/connection-layer.md) deep dive for implementation details.
 
 ### Performance Implications
 

--- a/docs/en/features/element-finding.md
+++ b/docs/en/features/element-finding.md
@@ -1031,6 +1031,6 @@ Want to dive deeper into element finding?
 
 - **[FindElements Mixin Deep Dive](../deep-dive/find-elements-mixin.md)**: Learn about the architecture, internal selector strategies, and performance optimizations
 - **[Selectors Guide](../deep-dive/selectors-guide.md)**: Comprehensive guide to CSS selectors and XPath with syntax references and real-world examples
-- **[WebElement Domain](../deep-dive/webelement-domain.md)**: Understand what you can do with elements once you've found them
+- **[WebElement Domain](../deep-dive/architecture/webelement-domain.md)**: Understand what you can do with elements once you've found them
 
 Element finding is the foundation of successful browser automation. Master these techniques, and you'll be able to reliably locate any element on any web page, no matter how complex the structure.


### PR DESCRIPTION
Fixes #309
Fixes #348

Some docs pages link to deep-dive files using their old paths. After a docs reorganization the files were moved into subcategories (`architecture/` and `fundamentals/`) but the links in the feature pages were not updated, causing 404s.

**core-concepts.md** (issue #309):
- `deep-dive/browser-domain.md` -> `deep-dive/architecture/browser-domain.md`
- `deep-dive/connection-layer.md` -> `deep-dive/fundamentals/connection-layer.md` (2 occurrences)
- `deep-dive/cdp.md` -> `deep-dive/fundamentals/cdp.md`

**element-finding.md** (issue #348):
- `deep-dive/webelement-domain.md` -> `deep-dive/architecture/webelement-domain.md`

All target files exist at the corrected paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation links to reference reorganized reference materials, improving navigation to in-depth learning resources on architecture and fundamentals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->