### PR TITLE
Fix find()/query() overloads for strict type checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,5 +166,3 @@ cython_debug/
 # Dev test file
 dev_test_file.py
 
-# pi coding agent
-.pi/

--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ cython_debug/
 
 # Dev test file
 dev_test_file.py
+
+# pi coding agent
+.pi/

--- a/.gitignore
+++ b/.gitignore
@@ -165,4 +165,3 @@ cython_debug/
 
 # Dev test file
 dev_test_file.py
-

--- a/pydoll/elements/mixins/find_elements_mixin.py
+++ b/pydoll/elements/mixins/find_elements_mixin.py
@@ -160,6 +160,20 @@ class FindElementsMixin:
         tag_name: Optional[str] = ...,
         text: Optional[str] = ...,
         timeout: int = ...,
+        find_all: Literal[True] = True,
+        raise_exc: bool = ...,
+        **attributes: str,
+    ) -> Optional[list[WebElement]]: ...
+
+    @overload
+    async def find(
+        self,
+        id: Optional[str] = ...,
+        class_name: Optional[str] = ...,
+        name: Optional[str] = ...,
+        tag_name: Optional[str] = ...,
+        text: Optional[str] = ...,
+        timeout: int = ...,
         find_all: bool = ...,
         raise_exc: bool = ...,
         **attributes: str,
@@ -287,6 +301,15 @@ class FindElementsMixin:
         find_all: Literal[False] = False,
         raise_exc: bool = ...,
     ) -> Optional[WebElement]: ...
+
+    @overload
+    async def query(
+        self,
+        expression: str,
+        timeout: int = ...,
+        find_all: Literal[True] = True,
+        raise_exc: bool = ...,
+    ) -> Optional[list[WebElement]]: ...
 
     @overload
     async def query(
@@ -659,7 +682,7 @@ class FindElementsMixin:
         name: Optional[str] = None,
         tag_name: Optional[str] = None,
         text: Optional[str] = None,
-        **attributes,
+        **attributes: str,
     ) -> tuple[By, str]:
         """
         Determine appropriate selector strategy and value from provided arguments.

--- a/pydoll/elements/mixins/find_elements_mixin.py
+++ b/pydoll/elements/mixins/find_elements_mixin.py
@@ -276,6 +276,24 @@ class FindElementsMixin:
         expression: str,
         timeout: int = ...,
         find_all: bool = ...,
+        raise_exc: Literal[True] = True,
+    ) -> Union[WebElement, list[WebElement]]: ...
+
+    @overload
+    async def query(
+        self,
+        expression: str,
+        timeout: int = ...,
+        find_all: Literal[False] = False,
+        raise_exc: bool = ...,
+    ) -> Optional[WebElement]: ...
+
+    @overload
+    async def query(
+        self,
+        expression: str,
+        timeout: int = ...,
+        find_all: bool = ...,
         raise_exc: bool = ...,
     ) -> Union[WebElement, list[WebElement], None]: ...
 

--- a/pydoll/elements/mixins/find_elements_mixin.py
+++ b/pydoll/elements/mixins/find_elements_mixin.py
@@ -133,6 +133,34 @@ class FindElementsMixin:
         text: Optional[str] = ...,
         timeout: int = ...,
         find_all: bool = ...,
+        raise_exc: Literal[True] = True,
+        **attributes,
+    ) -> Union[WebElement, list[WebElement]]: ...
+
+    @overload
+    async def find(
+        self,
+        id: Optional[str] = ...,
+        class_name: Optional[str] = ...,
+        name: Optional[str] = ...,
+        tag_name: Optional[str] = ...,
+        text: Optional[str] = ...,
+        timeout: int = ...,
+        find_all: Literal[False] = False,
+        raise_exc: bool = ...,
+        **attributes,
+    ) -> Optional[WebElement]: ...
+
+    @overload
+    async def find(
+        self,
+        id: Optional[str] = ...,
+        class_name: Optional[str] = ...,
+        name: Optional[str] = ...,
+        tag_name: Optional[str] = ...,
+        text: Optional[str] = ...,
+        timeout: int = ...,
+        find_all: bool = ...,
         raise_exc: bool = ...,
         **attributes,
     ) -> Union[WebElement, list[WebElement], None]: ...

--- a/pydoll/elements/mixins/find_elements_mixin.py
+++ b/pydoll/elements/mixins/find_elements_mixin.py
@@ -78,7 +78,7 @@ class FindElementsMixin:
         timeout: int = ...,
         find_all: Literal[False] = False,
         raise_exc: Literal[True] = True,
-        **attributes,
+        **attributes: str,
     ) -> WebElement: ...
 
     @overload
@@ -92,7 +92,7 @@ class FindElementsMixin:
         timeout: int = ...,
         find_all: Literal[False] = False,
         raise_exc: Literal[False] = False,
-        **attributes,
+        **attributes: str,
     ) -> Optional[WebElement]: ...
 
     @overload
@@ -106,7 +106,7 @@ class FindElementsMixin:
         timeout: int = ...,
         find_all: Literal[True] = True,
         raise_exc: Literal[True] = True,
-        **attributes,
+        **attributes: str,
     ) -> list[WebElement]: ...
 
     @overload
@@ -120,7 +120,7 @@ class FindElementsMixin:
         timeout: int = ...,
         find_all: Literal[True] = True,
         raise_exc: Literal[False] = False,
-        **attributes,
+        **attributes: str,
     ) -> Optional[list[WebElement]]: ...
 
     @overload
@@ -134,7 +134,7 @@ class FindElementsMixin:
         timeout: int = ...,
         find_all: bool = ...,
         raise_exc: Literal[True] = True,
-        **attributes,
+        **attributes: str,
     ) -> Union[WebElement, list[WebElement]]: ...
 
     @overload
@@ -148,7 +148,7 @@ class FindElementsMixin:
         timeout: int = ...,
         find_all: Literal[False] = False,
         raise_exc: bool = ...,
-        **attributes,
+        **attributes: str,
     ) -> Optional[WebElement]: ...
 
     @overload
@@ -162,7 +162,7 @@ class FindElementsMixin:
         timeout: int = ...,
         find_all: bool = ...,
         raise_exc: bool = ...,
-        **attributes,
+        **attributes: str,
     ) -> Union[WebElement, list[WebElement], None]: ...
 
     async def find(
@@ -175,7 +175,7 @@ class FindElementsMixin:
         timeout: int = 0,
         find_all: bool = False,
         raise_exc: bool = True,
-        **attributes: dict[str, str],
+        **attributes: str,
     ) -> Union[WebElement, list[WebElement], None]:
         """
         Find element(s) using combination of common HTML attributes.


### PR DESCRIPTION
## Summary

The find() and query() overloads were missing signatures for when find_all or raise_exc are passed as a generic bool variable (not a literal). This caused false-positive errors under strict Pyright/PyLance checking.

Also fixed the **attributes parameter type annotation from dict[str, str] (which was semantically wrong for **kwargs) to correctly typed str.

## Changes

- Added 2 new @overload signatures for find():
  - `find_all: bool, raise_exc: Literal[True]` -> `WebElement | list[WebElement]`
  - `find_all: Literal[False], raise_exc: bool` -> `Optional[WebElement]`
- Added the same 2 overloads for query()
- Fixed **attributes type from untyped/dict[str, str] to str in all overloads and the implementation

## Verification

All usage patterns pass with 0 errors under pyright:

```
await tab.find(id="x")                              # WebElement
await tab.find(id="x", raise_exc=False)             # WebElement | None
await tab.find(id="x", find_all=True)               # list[WebElement]
await tab.find(id="x", find_all=True, raise_exc=False)  # list[WebElement] | None
await tab.find(id="x", find_all=flag)               # WebElement | list[WebElement]
await tab.find(id="x", raise_exc=flag)              # WebElement | None
await tab.find(tag_name="input", type="email")      # WebElement
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal type annotations for element-finding methods to enhance code reliability and development experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->